### PR TITLE
Handle limit in store select more explicitly.

### DIFF
--- a/pb-coroutines-core/src/main/kotlin/io/provenance/coroutines/channels/ChannelExtensions.kt
+++ b/pb-coroutines-core/src/main/kotlin/io/provenance/coroutines/channels/ChannelExtensions.kt
@@ -2,11 +2,15 @@ package io.provenance.coroutines.channels
 
 import kotlinx.coroutines.channels.ReceiveChannel
 
-fun <T> ReceiveChannel<T>.receiveQueued(): List<T> {
+fun <T> ReceiveChannel<T>.receiveQueued(n: Int = Int.MAX_VALUE): List<T> {
     val list = mutableListOf<T>()
 
     var item: T?
     do {
+        if (list.size >= n) {
+            return list
+        }
+
         item = tryReceive().getOrNull()
         if (item != null) {
             list.add(item)

--- a/pb-coroutines-core/src/test/kotlin/io/provenance/coroutines/channels/ChannelExtensionsTest.kt
+++ b/pb-coroutines-core/src/test/kotlin/io/provenance/coroutines/channels/ChannelExtensionsTest.kt
@@ -3,6 +3,7 @@ package io.provenance.coroutines.channels
 import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.collections.shouldBeSorted
 import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.toList
 
@@ -25,8 +26,29 @@ class ChannelExtensionsTest : AnnotationSpec() {
         val chan = list.asChannel()
 
         val recv = chan.receiveQueued()
-        val recvList = recv.toList()
         recv.shouldContainAll(list)
+        recv.shouldBeSorted()
+    }
+
+    @Test
+    suspend fun testReceiveChannelReceiveQueuedLimited() {
+        val list = listOf<Int>() + 1 + 2 + 3
+        val chan = list.asChannel()
+
+        val recv = chan.receiveQueued(1)
+        recv.shouldContainAll(list.subList(0, 0))
+        recv.shouldBeSorted()
+        recv.first().shouldBe(1)
+    }
+
+    @Test
+    suspend fun testReceiveChannelReceiveQueuedLimitedBounded() {
+        val list = listOf<Int>() + 1 + 2 + 3
+        val chan = list.asChannel()
+
+        val recv = chan.receiveQueued(100)
+        recv.shouldContainAll(list)
+        recv.size.shouldBe(3)
         recv.shouldBeSorted()
     }
 }

--- a/pb-coroutines-kafka-retry/src/main/kotlin/io/provenance/kafka/coroutines/retry/Consts.kt
+++ b/pb-coroutines-kafka-retry/src/main/kotlin/io/provenance/kafka/coroutines/retry/Consts.kt
@@ -3,7 +3,7 @@ package io.provenance.kafka.coroutines.retry
 /**
  *
  */
-const val DEFAULT_RECORD_REPROCESS_GROUP_SIZE = 10
+internal const val DEFAULT_RECORD_REPROCESS_GROUP_SIZE = 40
 
 /**
  *

--- a/pb-coroutines-kafka-retry/src/main/kotlin/io/provenance/kafka/coroutines/retry/flow/KafkaFlowRetry.kt
+++ b/pb-coroutines-kafka-retry/src/main/kotlin/io/provenance/kafka/coroutines/retry/flow/KafkaFlowRetry.kt
@@ -30,8 +30,9 @@ open class KafkaFlowRetry<K, V>(
 
     override suspend fun produceNext(
         attemptRange: IntRange,
-        olderThan: OffsetDateTime
-    ) = store.select(attemptRange, olderThan).sortedByDescending { it.lastAttempted }.take(groupSize).asFlow()
+        olderThan: OffsetDateTime,
+        limit: Int,
+    ) = store.select(attemptRange, olderThan, limit).sortedByDescending { it.lastAttempted }.asFlow()
 
     override suspend fun send(
         item: ConsumerRecord<K, V>,

--- a/pb-coroutines-kafka-retry/src/main/kotlin/io/provenance/kafka/coroutines/retry/store/InMemoryConsumerRecordStore.kt
+++ b/pb-coroutines-kafka-retry/src/main/kotlin/io/provenance/kafka/coroutines/retry/store/InMemoryConsumerRecordStore.kt
@@ -13,11 +13,13 @@ fun <K, V> inMemoryConsumerRecordStore(
 
     override suspend fun select(
         attemptRange: IntRange,
-        lastAttempted: OffsetDateTime
+        lastAttempted: OffsetDateTime,
+        limit: Int,
     ): List<RetryRecord<ConsumerRecord<K, V>>> {
         return data
             .filter { it.attempt in attemptRange && it.lastAttempted.isBefore(lastAttempted) }
             .sortedBy { it.data.timestamp() }
+            .take(limit)
     }
 
     override suspend fun getOne(

--- a/pb-coroutines-retry/src/main/kotlin/io/provenance/coroutines/retry/flow/Consts.kt
+++ b/pb-coroutines-retry/src/main/kotlin/io/provenance/coroutines/retry/flow/Consts.kt
@@ -1,0 +1,6 @@
+package io.provenance.coroutines.retry.flow
+
+/**
+ *
+ */
+internal const val DEFAULT_FETCH_LIMIT = 40

--- a/pb-coroutines-retry/src/main/kotlin/io/provenance/coroutines/retry/flow/FlowRetry.kt
+++ b/pb-coroutines-retry/src/main/kotlin/io/provenance/coroutines/retry/flow/FlowRetry.kt
@@ -13,9 +13,10 @@ interface FlowRetry<T> : FlowProcessor<T> {
      *
      * @param attemptRange Only select records with [RetryRecord.attempt] in [attemptRange].
      * @param olderThan Only select records with [RetryRecord.lastAttempted] being before [olderThan].
+     * @param limit Limit the returned result to a set count of records.
      * @return A [Flow] of [RetryRecord] to process and feed into [process].
      */
-    suspend fun produceNext(attemptRange: IntRange, olderThan: OffsetDateTime): Flow<RetryRecord<T>>
+    suspend fun produceNext(attemptRange: IntRange, olderThan: OffsetDateTime, limit: Int = DEFAULT_FETCH_LIMIT): Flow<RetryRecord<T>>
 
     /**
      * Callback executed after successful processing of [process].

--- a/pb-coroutines-retry/src/main/kotlin/io/provenance/coroutines/retry/flow/RetryFlow.kt
+++ b/pb-coroutines-retry/src/main/kotlin/io/provenance/coroutines/retry/flow/RetryFlow.kt
@@ -32,6 +32,7 @@ internal val DEFAULT_RETRY_INTERVAL = 10.seconds
 fun <T> retryFlow(
     flowRetry: FlowRetry<T>,
     retryInterval: Duration = DEFAULT_RETRY_INTERVAL,
+    batchSize: Int = DEFAULT_FETCH_LIMIT,
     retryStrategies: List<RetryStrategy> = defaultRetryStrategies
 ): Flow<T> {
     val log = KotlinLogging.logger {}
@@ -46,7 +47,7 @@ fun <T> retryFlow(
                 flowRetry.onFailure(rec, it)
             }
 
-            flowRetry.produceNext(strategy.key, lastAttempted)
+            flowRetry.produceNext(strategy.key, lastAttempted, batchSize)
                 .onStart {
                     log.trace { "${strategy.value.name} --> Retrying records in group:${strategy.key} lastAttempted:$lastAttempted" }
                 }

--- a/pb-coroutines-retry/src/main/kotlin/io/provenance/coroutines/retry/flow/SimpleQueueFlowRetry.kt
+++ b/pb-coroutines-retry/src/main/kotlin/io/provenance/coroutines/retry/flow/SimpleQueueFlowRetry.kt
@@ -22,8 +22,8 @@ class SimpleChannelFlowRetry<T>(
         block(item, attempt)
     }
 
-    override suspend fun produceNext(attemptRange: IntRange, olderThan: OffsetDateTime): Flow<RetryRecord<T>> {
-        return queue.receiveQueued().asFlow()
+    override suspend fun produceNext(attemptRange: IntRange, olderThan: OffsetDateTime, limit: Int): Flow<RetryRecord<T>> {
+        return queue.receiveQueued(limit).asFlow()
     }
 
     override suspend fun onSuccess(item: RetryRecord<T>) {

--- a/pb-coroutines-retry/src/main/kotlin/io/provenance/coroutines/retry/store/RetryRecordStore.kt
+++ b/pb-coroutines-retry/src/main/kotlin/io/provenance/coroutines/retry/store/RetryRecordStore.kt
@@ -1,9 +1,10 @@
 package io.provenance.coroutines.retry.store
 
+import io.provenance.coroutines.retry.flow.DEFAULT_FETCH_LIMIT
 import java.time.OffsetDateTime
 
 interface RetryRecordStore<T> {
-    suspend fun select(attemptRange: IntRange, lastAttempted: OffsetDateTime): List<RetryRecord<T>>
+    suspend fun select(attemptRange: IntRange, lastAttempted: OffsetDateTime, limit: Int = DEFAULT_FETCH_LIMIT): List<RetryRecord<T>>
     suspend fun getOne(item: T): RetryRecord<T>?
     suspend fun putOne(item: T, lastException: Throwable? = null, mutator: RetryRecord<T>.() -> Unit)
     suspend fun remove(item: T)


### PR DESCRIPTION
* Add limit params to FlowRetry and RecordStore types to take the burden off implementer to decide how many records to return.