### PR TITLE
Guarantee ordering by grouping by topic-partition before sending down the channel.

### DIFF
--- a/pb-coroutines-kafka/src/main/kotlin/io/provenance/kafka/records/UnAckedConsumerRecord.kt
+++ b/pb-coroutines-kafka/src/main/kotlin/io/provenance/kafka/records/UnAckedConsumerRecord.kt
@@ -58,3 +58,8 @@ class UnAckedConsumerRecordImpl<K, V>(
             value:$value)
         """.trimIndent().split('\n').joinToString { it.trim() }
 }
+
+@JvmInline
+value class UnAckedConsumerRecords<K, V>(val records: List<UnAckedConsumerRecord<K, V>>) : Iterable<UnAckedConsumerRecord<K, V>> {
+    override fun iterator(): Iterator<UnAckedConsumerRecord<K, V>> = records.iterator()
+}


### PR DESCRIPTION
* this has to be done as a group to maintain the per-partition ordering of keys received from kafka